### PR TITLE
Update dockerfile_agent

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
+*.png
 docker-compose.yml
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/dockerfile_agent
+++ b/dockerfile_agent
@@ -1,12 +1,20 @@
-FROM ubuntu:latest
+FROM python:3.6-slim-stretch
+
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update -y --fix-missing && \
-    apt-get install -y python3 python3-pip python3-dev build-essential git openssl
+    apt-get install -y -q \
+        build-essential \
+        openssl \
+        git \
+        libssl-dev \
+        libffi-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONIOENCODING=utf-8
 
 COPY requirements.txt /
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 RUN mkdir dp-agent
 WORKDIR /dp-agent


### PR DESCRIPTION
* Use base image with Python3.6 (was 3.5)
* Install `libssl-dev` & `libffi-dev`, required for cryptography module
* Remove apt & pip caches to reduce image size
* Add `.dockerignore` file to prevent adding garbage to images
* Add generated `docker-compose.yml` to `.gitignore` and `.dockerignore`
