### PR TITLE
Fix/fixing resolving docker host

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Running Agent
 
 Agent can run both from container and from a local machine.
 
+Please consider setting your locale according your input language to avoid decoding errors while communicating agent via command line.
+
 **Container**
 
 1. Connect to agent container ([more information](https://docs.docker.com/engine/reference/commandline/exec/)):

--- a/core/config.py
+++ b/core/config.py
@@ -1,4 +1,6 @@
 import sys
+from os import getenv
+from itertools import chain
 from copy import deepcopy
 from pathlib import Path
 
@@ -21,7 +23,8 @@ SKILLS = [
     # },
     {
         "name": "chitchat",
-        "host": "http://chitchat",
+        "protocol": "http",
+        "host": "127.0.0.1",
         "port": 2081,
         "endpoint": "skill",
         "path": "skills/ranking_chitchat/agent_ranking_chitchat_2staged_tfidf_smn_v4_prep.json",
@@ -67,7 +70,8 @@ SKILLS = [
 ANNOTATORS = [
     {
         "name": "ner",
-        "host": "http://ner",
+        "protocol": "http",
+        "host": "127.0.0.1",
         "port": 2083,
         "endpoint": "skill",
         "path": "annotators/ner/preproc_ner_rus.json",
@@ -77,7 +81,8 @@ ANNOTATORS = [
     },
     {
         "name": "sentiment",
-        "host": "http://sentiment",
+        "protocol": "http",
+        "host": "127.0.0.1",
         "port": 2084,
         "endpoint": "skill",
         "path": "annotators/sentiment/preproc_rusentiment.json",
@@ -87,7 +92,8 @@ ANNOTATORS = [
     },
     {
         "name": "obscenity",
-        "host": "http://obscenity",
+        "protocol": "http",
+        "host": "127.0.0.1",
         "port": 2088,
         "endpoint": "skill",
         "path": "annotators/obscenity/obscenity_classifier.json",
@@ -100,7 +106,8 @@ ANNOTATORS = [
 SKILL_SELECTORS = [
     {
         "name": "chitchat_odqa",
-        "host": "http://chitchat_odqa",
+        "protocol": "http",
+        "host": "127.0.0.1",
         "port": 2082,
         "endpoint": "skill",
         "path": "skill_selectors/chitchat_odqa_selector/sselector_chitchat_odqa.json",
@@ -119,6 +126,11 @@ POSTPROCESSORS = [
 ]
 
 # TODO include Bot?
+
+# generate component url
+for service in chain(ANNOTATORS, SKILL_SELECTORS, SKILLS, RESPONSE_SELECTORS, POSTPROCESSORS):
+    host = service['name'] if getenv('DPA_LAUNCHING_ENV') == 'docker' else service['host']
+    service['url'] = f"{service['protocol']}://{host}:{service['port']}/{service['endpoint']}"
 
 
 def _get_config_path(component_config: dict) -> dict:

--- a/core/config.py
+++ b/core/config.py
@@ -8,6 +8,9 @@ import yaml
 
 # from deeppavlov import configs
 
+TELEGRAM_TOKEN = ''
+TELEGRAM_PROXY = ''
+
 DB_NAME = 'test'
 HOST = '127.0.0.1'
 PORT = 27017
@@ -133,6 +136,8 @@ for service in chain(ANNOTATORS, SKILL_SELECTORS, SKILLS, RESPONSE_SELECTORS, PO
     service['url'] = f"{service['protocol']}://{host}:{service['port']}/{service['endpoint']}"
 
 HOST = 'mongo' if getenv('DPA_LAUNCHING_ENV') == 'docker' else HOST
+TELEGRAM_TOKEN = TELEGRAM_TOKEN or getenv('TELEGRAM_TOKEN')
+TELEGRAM_PROXY = TELEGRAM_PROXY or getenv('TELEGRAM_PROXY')
 
 
 def _get_config_path(component_config: dict) -> dict:

--- a/core/config.py
+++ b/core/config.py
@@ -9,7 +9,7 @@ import yaml
 # from deeppavlov import configs
 
 DB_NAME = 'test'
-HOST = 'mongo'
+HOST = '127.0.0.1'
 PORT = 27017
 
 MAX_WORKERS = 4
@@ -131,6 +131,8 @@ POSTPROCESSORS = [
 for service in chain(ANNOTATORS, SKILL_SELECTORS, SKILLS, RESPONSE_SELECTORS, POSTPROCESSORS):
     host = service['name'] if getenv('DPA_LAUNCHING_ENV') == 'docker' else service['host']
     service['url'] = f"{service['protocol']}://{host}:{service['port']}/{service['endpoint']}"
+
+HOST = 'mongo' if getenv('DPA_LAUNCHING_ENV') == 'docker' else HOST
 
 
 def _get_config_path(component_config: dict) -> dict:

--- a/core/connection.py
+++ b/core/connection.py
@@ -1,9 +1,6 @@
 from mongoengine import connect
 
-from os import getenv
 from core.config import HOST, PORT, DB_NAME
 
-if getenv('DPA_LAUNCHING_ENV') != 'docker':
-    HOST = '0.0.0.0'
 
 state_storage = connect(host=HOST, port=PORT, db=DB_NAME)

--- a/core/run.py
+++ b/core/run.py
@@ -6,7 +6,6 @@ from multiprocessing import Process, Pipe
 from multiprocessing.connection import Connection
 from typing import Callable, Optional, Collection, Hashable, List, Tuple
 from os import getenv
-from itertools import chain
 
 import telebot
 from telebot.types import Message, Location, User
@@ -93,12 +92,6 @@ def run():
         POSTPROCESSORS
 
     import logging
-
-    for service in chain(ANNOTATORS, SKILL_SELECTORS, SKILLS, RESPONSE_SELECTORS, POSTPROCESSORS):
-        if getenv('DPA_LAUNCHING_ENV') != 'docker':
-            if not service.get('external', False):
-                service['host'] = 'http://0.0.0.0'
-        service['url'] = f"{service['host']}:{service['port']}/{service['endpoint']}"
 
     logging.getLogger('requests.packages.urllib3.connectionpool').setLevel(logging.WARNING)
 

--- a/core/run.py
+++ b/core/run.py
@@ -5,10 +5,12 @@ from threading import Thread
 from multiprocessing import Process, Pipe
 from multiprocessing.connection import Connection
 from typing import Callable, Optional, Collection, Hashable, List, Tuple
-from os import getenv
 
 import telebot
 from telebot.types import Message, Location, User
+
+from core.config import TELEGRAM_TOKEN, TELEGRAM_PROXY
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-ch", "--channel", help="run agent in telegram or cmd_client", type=str,
@@ -88,8 +90,7 @@ def run():
     from core.postprocessor import DefaultPostprocessor
     from core.response_selector import ConfidenceResponseSelector
     from core.skill_selector import ChitchatQASelector
-    from core.config import MAX_WORKERS, ANNOTATORS, SKILL_SELECTORS, SKILLS, RESPONSE_SELECTORS, \
-        POSTPROCESSORS
+    from core.config import MAX_WORKERS, ANNOTATORS, SKILL_SELECTORS, SKILLS
 
     import logging
 
@@ -154,7 +155,7 @@ def run():
 
 def main():
     if CHANNEL == 'telegram':
-        experimental_bot(run, token=getenv('TELEGRAM_TOKEN'), proxy=getenv('TELEGRAM_PROXY'))
+        experimental_bot(run, token=TELEGRAM_TOKEN, proxy=TELEGRAM_PROXY)
     else:
         message_processor = run()
         user_id = input('Provide user id: ')

--- a/core/run_dp_servers.py
+++ b/core/run_dp_servers.py
@@ -92,8 +92,6 @@ def skill_server(config: Union[dict, str, Path], https=False, ssl_key=None, ssl_
                  download: bool = True, batch_size: Optional[int] = None, env: Optional[Dict[str, str]] = None):
     if env:
         os.environ.update(env)
-    if host.startswith('http://'):
-        host = host[7:]
     host = host or '0.0.0.0'
     port = port or 80
     endpoint = f'/{endpoint}' or '/skill'

--- a/core/skill_manager.py
+++ b/core/skill_manager.py
@@ -58,7 +58,9 @@ class SkillManager:
     def get_skill_responses(self, dialogs):
         n_dialogs = len(dialogs)
         skill_names = [s['name'] for s in self.skills]
-        skill_urls = [f"{skill['host']}:{skill['port']}/{skill['endpoint']}" for skill in self.skills]
+
+        skill_urls = [skill['url'] for skill in self.skills]
+
         state = get_state(dialogs)
         if self.skill_selector is not None:
             selected_skills = self.skill_selector(state)
@@ -75,7 +77,7 @@ class SkillManager:
             compressed_dialogs = list(compress(s['dialogs'], map(operator.not_, exclude)))
             if not compressed_dialogs:
                 skill_names.remove(skill['name'])
-                skill_urls.remove(f"{skill['host']}:{skill['port']}/{skill['endpoint']}")
+                skill_urls.remove(skill['url'])
                 continue
             s['dialogs'] = compressed_dialogs
             payloads.append(s)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       args:
         skill_endpoint: skill
         skillconfig: skills/ranking_chitchat/agent_ranking_chitchat_2staged_tfidf_smn_v4_prep.json
-        skillhost: http://chitchat
+        skillhost: 0.0.0.0
         skillport: 2081
       context: ./
       dockerfile: dockerfile_skill_basic
@@ -38,7 +38,7 @@ services:
       args:
         skill_endpoint: skill
         skillconfig: skill_selectors/chitchat_odqa_selector/sselector_chitchat_odqa.json
-        skillhost: http://chitchat_odqa
+        skillhost: 0.0.0.0
         skillport: 2082
       context: ./
       dockerfile: dockerfile_skill_basic
@@ -62,7 +62,7 @@ services:
       args:
         skill_endpoint: skill
         skillconfig: annotators/ner/preproc_ner_rus.json
-        skillhost: http://ner
+        skillhost: 0.0.0.0
         skillport: 2083
       context: ./
       dockerfile: dockerfile_skill_basic
@@ -79,7 +79,7 @@ services:
       args:
         skill_endpoint: skill
         skillconfig: annotators/obscenity/obscenity_classifier.json
-        skillhost: http://obscenity
+        skillhost: 0.0.0.0
         skillport: 2088
       context: ./
       dockerfile: dockerfile_skill_basic
@@ -96,7 +96,7 @@ services:
       args:
         skill_endpoint: skill
         skillconfig: annotators/sentiment/preproc_rusentiment.json
-        skillhost: http://sentiment
+        skillhost: 0.0.0.0
         skillport: 2084
       context: ./
       dockerfile: dockerfile_skill_basic

--- a/dockerfile_skill_basic
+++ b/dockerfile_skill_basic
@@ -1,15 +1,5 @@
 FROM ubuntu:latest
 
-ARG skillconfig
-ARG skillport
-ARG skill_endpoint
-ARG skillhost
-
-ENV CONFIG=$skillconfig
-ENV PORT=$skillport
-ENV HOST=$skillhost
-ENV ENDPOINT=$skill_endpoint
-
 RUN apt-get update -y --fix-missing && \
     apt-get install -y python3 python3-pip python3-dev build-essential git openssl
 
@@ -19,6 +9,16 @@ RUN mkdir dp-agent
 WORKDIR /dp-agent
 COPY . /dp-agent/.
 ENV PYTHONPATH "${PYTONPATH}:/dp-agent"
+
+ARG skillconfig
+ARG skillport
+ARG skill_endpoint
+ARG skillhost
+
+ENV CONFIG=$skillconfig
+ENV PORT=$skillport
+ENV HOST=$skillhost
+ENV ENDPOINT=$skill_endpoint
 
 RUN python3 -m deeppavlov install $CONFIG
 ENTRYPOINT python3 -m core.run_dp_servers $CONFIG -p $PORT -host $HOST -ep $ENDPOINT

--- a/generate_composefile.py
+++ b/generate_composefile.py
@@ -91,7 +91,7 @@ class SkillConfig(Config):
 
 class DatabaseConfig:
     def __init__(self, host, port, template=None):
-        if template is None and host == 'mongo':
+        if template is None and host == '127.0.0.1':
             self.template = deepcopy(MONGO_BASIC)
             self.container_name = 'mongo'
             self.template['mongo']['ports'][0] = self.template['mongo']['ports'][0].format(port)

--- a/generate_composefile.py
+++ b/generate_composefile.py
@@ -81,7 +81,7 @@ class SkillConfig(Config):
         self.template['build']['args']['skillport'] = skill_config['port']
         self.template['build']['args']['skillconfig'] = skill_config['path']
         self.template['build']['args']['skill_endpoint'] = skill_config['endpoint']
-        self.template['build']['args']['skillhost'] = skill_config['host']
+        self.template['build']['args']['skillhost'] = '0.0.0.0'
         self.template['ports'].append("{}:{}".format(skill_config['port'], skill_config['port']))
 
     @property


### PR DESCRIPTION
1) Обновлён dockerfile для скиллов: комманды сборки поменяны местами для переиспользования максимально большего количества слоёв;
2) Flask, сервящий скиллы в докер-контейнерах, всегда разворачивается на 0.0.0.0;
3) Явно разведены параметры host и protocol в контейнере. Раньше значения параметра host имели вид "http://hostname", что являлось не совсем корректным; кроме того, параметром protocol можно в дальнейшем будет включать запуск скиллов на https;
4) Дефолтные значения параметра host в конфиге изменены с имён скиллов на 127.0.0.1, что позволит без правок запускать контейнер с хоста при скиллах, поднятых на нём в docker контейнерах;
5) Выполняющаяся в трёх различных местах кода операция по генерации url скиллов перемещена в config.py, там сейчас происходит проверка переменной `DPA_LAUNCHING_ENV` и замена в url хостов на имена скиллов, если скилл запускается внутри контейнера;
6) TELEGRAM_TOKEN и TELEGRAM_PROXY теперь можно задать в config.py, режим интеракции с агентом через Телегу стал доступен из докера.