### PR TITLE
fix: custom config

### DIFF
--- a/dp/dockerfile_skill
+++ b/dp/dockerfile_skill
@@ -10,6 +10,10 @@ ENV TFHUB_CACHE_DIR=/tmp/tfhub
 
 VOLUME /tmp/tfhub
 
+WORKDIR dp-agent
+
+COPY . /base/dp-agent
+
 RUN python -m deeppavlov install $CONFIG && \
     sed -i "/uvicorn.run/s/app,/app, timeout_keep_alive=20,/g" "/base/DeepPavlov/deeppavlov/utils/server/server.py"
 


### PR DESCRIPTION
Custom config (not presented in DeepPavlov lib) located at dp-agent could be used again