### PR TITLE
fix: correct adding hyps annotations

### DIFF
--- a/deeppavlov_agent/core/state_manager.py
+++ b/deeppavlov_agent/core/state_manager.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Dict
 
 from datetime import datetime
@@ -37,7 +38,6 @@ class StateManager:
         if isinstance(dialog.utterances[-1], BotUtterance):
             return
         if len(dialog.utterances[-1].hypotheses) != len(payload["batch"]):
-            logger.error(f'hypots len: {len(dialog.utterances[-1].hypotheses)} != batch len {len(payload["batch"])}')
             for i in range(len(dialog.utterances[-1].hypotheses)):
                 dialog.utterances[-1].hypotheses[i]['annotations'][label] = {}
         else:

--- a/deeppavlov_agent/core/state_manager.py
+++ b/deeppavlov_agent/core/state_manager.py
@@ -37,11 +37,14 @@ class StateManager:
         if isinstance(dialog.utterances[-1], BotUtterance):
             return
         if len(dialog.utterances[-1].hypotheses) != len(payload["batch"]):
+            logger.error(f'hypots len: {len(dialog.utterances[-1].hypotheses)} != batch len {len(payload["batch"])}')
             for i in range(len(dialog.utterances[-1].hypotheses)):
                 dialog.utterances[-1].hypotheses[i]['annotations'][label] = {}
         else:
             for i in range(len(payload["batch"])):
-                dialog.utterances[-1].hypotheses[i]['annotations'][label] = payload["batch"][i]
+                new_val = deepcopy(dialog.utterances[-1].hypotheses[i])
+                new_val['annotations'][label] = payload["batch"][i]
+                dialog.utterances[-1].hypotheses[i] = new_val
 
     async def add_text(self, dialog: Dialog, payload: str, label: str, **kwargs):
         dialog.utterances[-1].text = payload


### PR DESCRIPTION
the error is the following: for the different hypotheses from one skill, hypotheses annotations are assigned the same.
deepcopy fixes it.